### PR TITLE
[deploy.sh] fix node-gyp failure on rebuild

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -86,12 +86,7 @@ fi
 make -j 8
 
 cd ../gzbridge
-if [ -d "./build" ]; then
-  # node-gym configure will fail if build already exists
-  rm -rf ./build
-fi
-$DIR/node_modules/.bin/node-gyp configure
-$DIR/node_modules/.bin/node-gyp build -d
+$DIR/node_modules/.bin/node-gyp rebuild -d
 
 RETVAL=$?
 if [ $RETVAL -ne 0 ]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -86,6 +86,10 @@ fi
 make -j 8
 
 cd ../gzbridge
+if [ -d "./build" ]; then
+  # node-gym configure will fail if build already exists
+  rm -rf ./build
+fi
 $DIR/node_modules/.bin/node-gyp configure
 $DIR/node_modules/.bin/node-gyp build -d
 


### PR DESCRIPTION
node-gyp configure will fail if build directory already exists.

One reason this might already exists is if new models have been added
to the model path, and `npm run deploy --- -m local` is run again.

This change enables building a generic docker image for gzweb, and later
loading in the models at launch time via a volume mount that were not
known when the original gzweb image was built.