### PR TITLE
Pin node-gyp back to fix GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Node.js CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
 name: Node.js CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,6 @@
 name: Node.js CI
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     # - run: sudo chmod 755 /usr/bin/google-chrome
     # - run: defaults write com.google.chrome HardwareAccelerationModeEnabled -integer 1
     # - run: export DISPLAY=:0
-    - run: npm run deploy
+    - run: npm run deploy --verbose
     # - run: npm test
     # - run: npm run coverage
     - run: npm run update

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "fs": "0.0.1-security",
     "http": "0.0.0",
-    "node-gyp": "",
+    "node-gyp": "6.1.0",
     "path": "^0.12.7",
     "websocket": "^1.0.25"
   },


### PR DESCRIPTION
- Pin node-gyp to 6.1.0 which is the latest version where things don't break.
- update GitHub ci triggers to trigger on PRs to master and pushes to master
  - previously was only set to push, which would trigger all commits pushed to this repo directly. (no CI was triggered for contributions from users without push access to this repo, unless they modify the ci files)