### PR TITLE
Fix compilation against gazebo 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,8 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - run: sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+    - run: wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
     - run: sudo apt update
     - run: sudo apt install -y libjansson-dev libboost-dev imagemagick libtinyxml-dev git cmake build-essential wget libgazebo11-dev
     - run: sudo npm install -g grunt

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,39 @@
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+  bionic-ci:
+
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: sudo apt update
+    - run: sudo apt install -y libjansson-dev libboost-dev imagemagick libtinyxml-dev git cmake build-essential wget libgazebo9-dev
+    - run: sudo npm install -g grunt
+    # - run: sudo bash -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/chrome.list'
+    # - run: sudo wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+    # - run: sudo apt update
+    # - run: sudo apt install -y xvfb google-chrome-stable gnustep-base-runtime
+    # - run: sudo wget -q -O /usr/bin/xvfb-chrome https://gist.githubusercontent.com/chapulina/a80bd83d3494c96dc9eead843579c435/raw/7d304595d401c1265b533626d542ace7e6916002/xvfb-chrome
+    # - run: sudo ln -sf /usr/bin/xvfb-chrome /usr/bin/google-chrome
+    # - run: sudo chmod 755 /usr/bin/google-chrome
+    # - run: defaults write com.google.chrome HardwareAccelerationModeEnabled -integer 1
+    # - run: export DISPLAY=:0
+    - run: npm run deploy --verbose
+    # - run: npm test
+    # - run: npm run coverage
+    - run: npm run update
+    - run: npm run docs
+      env:
+        CI: true
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,3 +37,25 @@ jobs:
       env:
         CI: true
 
+  focal-ci:
+
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: sudo apt update
+    - run: sudo apt install -y libjansson-dev libboost-dev imagemagick libtinyxml-dev git cmake build-essential wget libgazebo11-dev
+    - run: sudo npm install -g grunt
+    - run: npm run deploy --verbose
+    - run: npm run update
+    - run: npm run docs
+      env:
+        CI: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -86,8 +86,7 @@ fi
 make -j 8
 
 cd ../gzbridge
-$DIR/node_modules/.bin/node-gyp configure
-$DIR/node_modules/.bin/node-gyp build -d
+$DIR/node_modules/.bin/node-gyp rebuild -d
 
 RETVAL=$?
 if [ $RETVAL -ne 0 ]; then

--- a/gzbridge/binding.gyp
+++ b/gzbridge/binding.gyp
@@ -14,6 +14,7 @@
           'cflags': [
             '<!@(pkg-config --cflags gazebo jansson protobuf)'
           ],
+          'cflags_cc': [ '-fno-rtti', '-fno-exceptions', '-std=c++17' ],
           'ldflags': [
             '<!@(pkg-config --libs-only-L --libs-only-other gazebo jansson protobuf)'
           ],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "gzweb",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "WebGL client for Gazebo",
   "repository": {
     "type": "mercurial",
-    "url": "https://bitbucket.org/osrf/gzweb"
+    "url": "https://github.com/osrf/gzweb"
   },
   "config": {
     "port": ""
@@ -20,7 +20,7 @@
   "dependencies": {
     "fs": "0.0.1-security",
     "http": "0.0.0",
-    "node-gyp": "",
+    "node-gyp": "6.1.0",
     "path": "^0.12.7",
     "websocket": "^1.0.25"
   },


### PR DESCRIPTION
Made a copule changes that allowed me to build gzweb against gazebo9 and gazebo11 on Bionic:
* ported a couple fixes from pull request #192 and #191 
* enabled the c++17 flag as suggested in issue #184 

I also fixed a link and gzweb version in package.json'

Update:

Instead making a PR against a release branch, I created a new `gzweb_1.4` dev branch for patches made against the 1.4 version. Once these changes get in, I can tag a `gzweb_1.4.1` release and update the instructions on http://gazebosim.org/gzweb.html. 

Signed-off-by: Ian Chen <ichen@osrfoundation.org>