### PR TITLE
Support resource files with spaces

### DIFF
--- a/gzbridge/ConfigLoader.cc
+++ b/gzbridge/ConfigLoader.cc
@@ -252,7 +252,12 @@ void ConfigLoader::_parseNodes(std::ifstream &stream, ConfigNode *parent)
 					}
 					else
 					{
-						key = newNode->getName() + ' ' + newNode->getValues().front();
+						key = newNode->getName();
+						for (auto value : newNode->getValues())
+						{
+							key += ' ' + value;
+						}
+						key.erase(std::remove(key.begin(), key.end(), '"'), key.end());
 					}
 
 					m_scriptList.insert(ScriptItem(key, newNode));

--- a/gzbridge/OgreMaterialParser.cc
+++ b/gzbridge/OgreMaterialParser.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 
@@ -150,7 +151,17 @@ std::string OgreMaterialParser::GetMaterialAsJson() const
           ConfigNode *textureNode = textureUnitNode->findChild("texture");
           if (textureNode)
           {
-            std::string textureStr = textureNode->getValue(0);
+            std::string textureStr;
+            for (auto i = 0u; i < textureNode->getValues().size(); ++i)
+            {
+              textureStr += textureNode->getValue(i);
+              if (i + 1 != textureNode->getValues().size())
+                textureStr += " ";
+            }
+
+            textureStr.erase(std::remove(textureStr.begin(),
+                textureStr.end(), '"'), textureStr.end());
+
             index = textureStr.rfind(".");
             if (index != std::string::npos)
             {

--- a/gzbridge/OgreMaterialParser.cc
+++ b/gzbridge/OgreMaterialParser.cc
@@ -51,7 +51,7 @@ std::string OgreMaterialParser::GetMaterialAsJson() const
         else
           first = false;
 
-        std::size_t index = name.rfind(" ");
+        std::size_t index = name.find(" ");
         if (index != std::string::npos)
         {
           name = name.substr(index+1);

--- a/gzbridge/server.js
+++ b/gzbridge/server.js
@@ -53,10 +53,11 @@ let staticServe = function(req, res) {
   if (req.url === '/')
     req.url = '/index.html';
 
-  fileLoc = path.join(fileLoc, req.url);
+  fileLoc = unescape(path.join(fileLoc, req.url));
 
   fs.readFile(fileLoc, function(err, data) {
     if (err) {
+        console.error('File not found [', fileLoc, ']');
         res.writeHead(404, 'Not Found');
         res.write('404: File Not Found!');
         return res.end();

--- a/webify_models_v2.py
+++ b/webify_models_v2.py
@@ -64,6 +64,11 @@ for file in files:
       print sed_cmd
       subprocess.check_call(sed_cmd)
 
+      # Decode whitespace
+      sed_cmd = ["sed", "-i", "-e", 's/%20/ /g', file]
+      print sed_cmd
+      subprocess.check_call(sed_cmd)
+
       # find relatvie path to texture dir
       texture_dir = path
       if (texture_dir.find('materials/textures') == -1 and
@@ -81,7 +86,7 @@ for file in files:
         subprocess.check_call(sed_cmd)
 
         sed_cmd = ["sed", "-i","-e",
-          '/[a-zA-Z0-9_\.\/\-]\+materials\/textures/!s/\([a-zA-Z0-9_\-]\+\)\(\.png\W\)/'+ relative_path + 'materials\/textures\/\\1\\2/g', file]
+          '/[a-zA-Z0-9_\.\/\-]\+materials\/textures/!s/\([a-zA-Z0-9_ \-]\+\)\(\.png\W\)/'+ relative_path + 'materials\/textures\/\\1\\2/g', file]
 
         print sed_cmd
         subprocess.check_call(sed_cmd)

--- a/webify_models_v2.py
+++ b/webify_models_v2.py
@@ -20,10 +20,11 @@ if sys.platform == 'darwin':
 
 path = sys.argv[1]
 
-files = os.listdir(path)
+# Unused
+# files = os.listdir(path)
 
 find_cmd = ['find', path, '-name','*']
-files = subprocess.check_output(find_cmd).split()
+files = subprocess.check_output(find_cmd).split('\n')
 
 for file in files:
   try:

--- a/webify_models_v2.py
+++ b/webify_models_v2.py
@@ -20,9 +20,6 @@ if sys.platform == 'darwin':
 
 path = sys.argv[1]
 
-# Unused
-# files = os.listdir(path)
-
 find_cmd = ['find', path, '-name','*']
 files = subprocess.check_output(find_cmd).split('\n')
 


### PR DESCRIPTION
Resolves #160 

Tested with https://github.com/osrf/gazebo/pull/2877/

I rebased @willcbaker's fix and built on top of it.

## Test it manually

1. Download these 2 models into `~/.gazebo/models`
    * https://app.ignitionrobotics.org/chapulina/fuel/models/Stop%20sign%20with%20spaces
    * https://app.ignitionrobotics.org/chapulina/fuel/models/Cordless%20drill%20with%20spaces
1. Source `gazebo/setup.sh` according to your installation.
1. Set env var: `GAZEBO_MODEL_PATH=$HOME/.gazebo/models:$GAZEBO_MODEL_PATH`
1. Redeploy to webify local models: `npm run deploy --- -m local`
1. Save this world as `spaces.world`:
    <details><summary>spaces.world</summary>
    <p>

    ```
    <?xml version="1.0" ?>
    <sdf version="1.5">
      <world name="default">
        <!-- A global light source -->
        <include>
          <uri>model://sun</uri>
        </include>
        <!-- A ground plane -->
        <include>
          <uri>model://ground_plane</uri>
        </include>
        <include>
          <uri>model://Stop sign with spaces</uri>
        </include>
        <include>
          <pose>3 0 0 0 0 0</pose>
          <uri>model://Cordless drill with spaces</uri>
        </include>
      </world>
    </sdf>

    ```

    </p>
    </details>
1. Start `gzserver spaces.world -u`
1. Start GzWeb: `npm start`

![image](https://user-images.githubusercontent.com/5751272/99127979-7745a900-25be-11eb-9536-9e2e79659d71.png)

## Supported file types

* Models with spaces (`Stop sign with spaces` / `Cordless drill with spaces`)
* Meshes with spaces (`cordless drill.dae` / `cordless drill.stl` / `stop sign.dae`)
* Material files with spaces (`stop sign.material`)
* Textures with spaces referenced from DAE (`cordless drill.png`)
* Textures with spaces referenced from Ogre material (`StopSign Diffuse.png` / `StopSign Spec.png`)