### PR TITLE
Add `.gitignore` that includes all of the Mercurial ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Build Outputs
+build
+gz3d/build
+build_*
+
+# Just Mac Things
+.DS_Store
+
+# Just IDE Things
+.vscode
+
+# Etc
+*.*~
+*~
+*.orig
+*.swp
+http/client/assets
+node_modules
+http/client
+coverage
+doc
+npm-debug.log
+test_results


### PR DESCRIPTION
This project had a Mercurial ignore, but it did not have a Git ignore.

This adds all the existing Mercurial ignores, as well as one additional `.vscode` one.