### PR TITLE
Add support to node 12.x and Gazebo 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,11 +5,11 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2
@@ -17,8 +17,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - run: sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+    - run: wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
     - run: sudo apt update
-    - run: sudo apt install -y libjansson-dev libboost-dev imagemagick libtinyxml-dev git cmake build-essential wget libgazebo7-dev
+    - run: sudo apt install -y libjansson-dev libboost-dev imagemagick libtinyxml-dev git cmake build-essential wget libgazebo11-dev
     - run: sudo npm install -g grunt
     # - run: sudo bash -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/chrome.list'
     # - run: sudo wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/gzbridge/GZNode.cc
+++ b/gzbridge/GZNode.cc
@@ -89,7 +89,7 @@ void GZNode::Init(Local<Object> exports)
 }
 
 /////////////////////////////////////////////////
-void GZNode::New(const FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::New)
 {
   if (args.IsConstructCall()) {
     // Invoked as constructor: `new MyObject(...)`
@@ -100,7 +100,7 @@ void GZNode::New(const FunctionCallbackInfo<Value>& args)
 }
 
 /////////////////////////////////////////////////
-void GZNode::LoadMaterialScripts(const FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::LoadMaterialScripts)
 {
   Isolate* isolate = args.GetIsolate();
 
@@ -131,7 +131,7 @@ void GZNode::LoadMaterialScripts(const FunctionCallbackInfo<Value>& args)
 }
 
 /////////////////////////////////////////////////
-void GZNode::SetConnected(const FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::SetConnected)
 {
   Isolate* isolate = args.GetIsolate();
 
@@ -149,7 +149,7 @@ void GZNode::SetConnected(const FunctionCallbackInfo<Value>& args)
 }
 
 /////////////////////////////////////////////////
-void GZNode::GetIsGzServerConnected(const FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::GetIsGzServerConnected)
 {
   GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
   bool value = obj->isGzServerConnected;
@@ -158,7 +158,7 @@ void GZNode::GetIsGzServerConnected(const FunctionCallbackInfo<Value>& args)
 }
 
 /////////////////////////////////////////////////
-void GZNode::GetMaterialScriptsMessage(const FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::GetMaterialScriptsMessage)
 {
   Isolate* isolate = args.GetIsolate();
 
@@ -198,8 +198,7 @@ void GZNode::GetMaterialScriptsMessage(const FunctionCallbackInfo<Value>& args)
 }
 
 /////////////////////////////////////////////////
-void GZNode::SetPoseMsgFilterMinimumDistanceSquared(const
-    FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::SetPoseMsgFilterMinimumDistanceSquared)
 {
   GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
 
@@ -211,8 +210,7 @@ void GZNode::SetPoseMsgFilterMinimumDistanceSquared(const
 }
 
 /////////////////////////////////////////////////
-void GZNode::GetPoseMsgFilterMinimumDistanceSquared(const
-    FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::GetPoseMsgFilterMinimumDistanceSquared)
 {
   Isolate* isolate = args.GetIsolate();
   GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
@@ -221,8 +219,7 @@ void GZNode::GetPoseMsgFilterMinimumDistanceSquared(const
 }
 
 /////////////////////////////////////////////////////
-void GZNode::SetPoseMsgFilterMinimumQuaternionSquared(const
-    FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::SetPoseMsgFilterMinimumQuaternionSquared)
 {
   GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
   Local<Number> v = Local<Number>::Cast(args[0]);
@@ -233,8 +230,7 @@ void GZNode::SetPoseMsgFilterMinimumQuaternionSquared(const
 }
 
 /////////////////////////////////////////////////
-void GZNode::GetPoseMsgFilterMinimumQuaternionSquared(const
-    FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::GetPoseMsgFilterMinimumQuaternionSquared)
 {
   Isolate* isolate = args.GetIsolate();
   GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
@@ -243,7 +239,7 @@ void GZNode::GetPoseMsgFilterMinimumQuaternionSquared(const
 }
 
 /////////////////////////////////////////////////
-void GZNode::GetMessages(const FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::GetMessages)
 {
   Isolate* isolate = args.GetIsolate();
   Local<Context> context = isolate->GetCurrentContext();
@@ -267,7 +263,7 @@ void GZNode::GetMessages(const FunctionCallbackInfo<Value>& args)
 
 
 ////////////////////////////////////////////////
-void GZNode::Request(const FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::Request)
 {
   Isolate* isolate = args.GetIsolate();
 
@@ -298,8 +294,7 @@ void GZNode::Request(const FunctionCallbackInfo<Value>& args)
 }
 
 /////////////////////////////////////////////////
-void GZNode::SetPoseMsgFilterMinimumAge(const
-    FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::SetPoseMsgFilterMinimumAge)
 {
   GZNode* obj = ObjectWrap::Unwrap<GZNode>(args.This());
   Local<Number> v = Local<Number>::Cast(args[0]);
@@ -310,8 +305,7 @@ void GZNode::SetPoseMsgFilterMinimumAge(const
 }
 
 /////////////////////////////////////////////////
-void GZNode::GetPoseMsgFilterMinimumAge(const
-    FunctionCallbackInfo<Value>& args)
+NAN_METHOD(GZNode::GetPoseMsgFilterMinimumAge)
 {
   GZNode* obj = ObjectWrap::Unwrap<GZNode>(args.This());
   double value  = obj->gzIface->GetPoseFilterMinimumMsgAge();

--- a/gzbridge/GZNode.cc
+++ b/gzbridge/GZNode.cc
@@ -96,6 +96,8 @@ NAN_METHOD(GZNode::New)
     GZNode* obj = new GZNode();
     obj->Wrap(info.This());
     info.GetReturnValue().Set(info.This());
+  }else{
+    return Nan::ThrowTypeError("GZNode::New - called without new keyword");
   }
 }
 
@@ -106,20 +108,12 @@ NAN_METHOD(GZNode::LoadMaterialScripts)
 
   if (info.Length() < 1)
   {
-    isolate->ThrowException(Exception::TypeError(
-      String::NewFromUtf8(isolate, 
-        "Wrong number of arguments", 
-        NewStringType::kNormal).ToLocalChecked()));
-    return;
+    return Nan::ThrowTypeError("GZNode::LoadMaterialScripts - Wrong number of arguments. One arg expected");
   }
 
   if (!info[0]->IsString())
   {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, 
-          "Wrong argument type. String expected.", 
-          NewStringType::kNormal).ToLocalChecked()));
-    return;
+    return Nan::ThrowTypeError("GZNode::LoadMaterialScripts - Wrong argument type. String expected.");
   }
 
   GZNode* obj = ObjectWrap::Unwrap<GZNode>(info.This());
@@ -164,20 +158,12 @@ NAN_METHOD(GZNode::GetMaterialScriptsMessage)
 
   if (info.Length() < 1)
   {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, 
-          "Wrong number of arguments", 
-          NewStringType::kNormal).ToLocalChecked()));
-    return;
+    return Nan::ThrowTypeError("GZNode::GetMaterialScriptsMessage - Wrong number of arguments. One arg expected.");
   }
 
   if (!info[0]->IsString())
   {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, 
-          "Wrong argument type. String expected.",
-          NewStringType::kNormal).ToLocalChecked()));
-    return;
+    return Nan::ThrowTypeError("GZNode::GetMaterialScriptsMessage - Wrong argument type. String expected.");
   }
 
   String::Utf8Value path(isolate, info[0]);
@@ -269,20 +255,12 @@ NAN_METHOD(GZNode::Request)
 
   if (info.Length() < 1)
   {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, 
-          "Wrong number of arguments", 
-          NewStringType::kNormal).ToLocalChecked()));
-    return;
+    return Nan::ThrowTypeError("GZNode::Request - Wrong number of arguments. One arg expected.");
   }
 
   if (!info[0]->IsString())
   {
-    isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, 
-          "Wrong argument type. String expected.",
-          NewStringType::kNormal).ToLocalChecked()));
-    return;
+    return Nan::ThrowTypeError("GZNode::Request - Wrong argument type. String expected.");
   }
 
   GZNode* obj = ObjectWrap::Unwrap<GZNode>(info.This());

--- a/gzbridge/GZNode.cc
+++ b/gzbridge/GZNode.cc
@@ -91,20 +91,20 @@ void GZNode::Init(Local<Object> exports)
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::New)
 {
-  if (args.IsConstructCall()) {
+  if (info.IsConstructCall()) {
     // Invoked as constructor: `new MyObject(...)`
     GZNode* obj = new GZNode();
-    obj->Wrap(args.This());
-    args.GetReturnValue().Set(args.This());
+    obj->Wrap(info.This());
+    info.GetReturnValue().Set(info.This());
   }
 }
 
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::LoadMaterialScripts)
 {
-  Isolate* isolate = args.GetIsolate();
+  Isolate* isolate = info.GetIsolate();
 
-  if (args.Length() < 1)
+  if (info.Length() < 1)
   {
     isolate->ThrowException(Exception::TypeError(
       String::NewFromUtf8(isolate, 
@@ -113,7 +113,7 @@ NAN_METHOD(GZNode::LoadMaterialScripts)
     return;
   }
 
-  if (!args[0]->IsString())
+  if (!info[0]->IsString())
   {
     isolate->ThrowException(Exception::TypeError(
         String::NewFromUtf8(isolate, 
@@ -122,9 +122,9 @@ NAN_METHOD(GZNode::LoadMaterialScripts)
     return;
   }
 
-  GZNode* obj = ObjectWrap::Unwrap<GZNode>(args.This());
+  GZNode* obj = ObjectWrap::Unwrap<GZNode>(info.This());
 
-  String::Utf8Value path(isolate, args[0]);
+  String::Utf8Value path(isolate, info[0]);
   obj->gzIface->LoadMaterialScripts(std::string(*path));
 
   return;
@@ -133,15 +133,15 @@ NAN_METHOD(GZNode::LoadMaterialScripts)
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::SetConnected)
 {
-  Isolate* isolate = args.GetIsolate();
+  Isolate* isolate = info.GetIsolate();
 
-  GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
+  GZNode *obj = ObjectWrap::Unwrap<GZNode>(info.This());
 
 #if NODE_MAJOR_VERSION<=10
   Local<Context> context = isolate->GetCurrentContext();
-  bool value = args[0]->BooleanValue(context).ToChecked();
+  bool value = info[0]->BooleanValue(context).ToChecked();
 #else
-  bool value = args[0]->BooleanValue(isolate);
+  bool value = info[0]->BooleanValue(isolate);
 #endif
   obj->gzIface->SetConnected(value);
 
@@ -151,18 +151,18 @@ NAN_METHOD(GZNode::SetConnected)
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::GetIsGzServerConnected)
 {
-  GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
+  GZNode *obj = ObjectWrap::Unwrap<GZNode>(info.This());
   bool value = obj->isGzServerConnected;
 
-  args.GetReturnValue().Set(value);
+  info.GetReturnValue().Set(value);
 }
 
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::GetMaterialScriptsMessage)
 {
-  Isolate* isolate = args.GetIsolate();
+  Isolate* isolate = info.GetIsolate();
 
-  if (args.Length() < 1)
+  if (info.Length() < 1)
   {
     isolate->ThrowException(Exception::TypeError(
         String::NewFromUtf8(isolate, 
@@ -171,7 +171,7 @@ NAN_METHOD(GZNode::GetMaterialScriptsMessage)
     return;
   }
 
-  if (!args[0]->IsString())
+  if (!info[0]->IsString())
   {
     isolate->ThrowException(Exception::TypeError(
         String::NewFromUtf8(isolate, 
@@ -180,7 +180,7 @@ NAN_METHOD(GZNode::GetMaterialScriptsMessage)
     return;
   }
 
-  String::Utf8Value path(isolate, args[0]);
+  String::Utf8Value path(isolate, info[0]);
 
   OgreMaterialParser materialParser;
   materialParser.Load(std::string(*path));
@@ -191,7 +191,7 @@ NAN_METHOD(GZNode::GetMaterialScriptsMessage)
   msg += materialJson;
   msg += "}";
 
-  args.GetReturnValue().Set(
+  info.GetReturnValue().Set(
     String::NewFromUtf8(isolate,
       msg.c_str(), 
       NewStringType::kNormal).ToLocalChecked());
@@ -200,9 +200,9 @@ NAN_METHOD(GZNode::GetMaterialScriptsMessage)
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::SetPoseMsgFilterMinimumDistanceSquared)
 {
-  GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
+  GZNode *obj = ObjectWrap::Unwrap<GZNode>(info.This());
 
-  Local<Number> v = Local<Number>::Cast(args[0]);
+  Local<Number> v = Local<Number>::Cast(info[0]);
   double value = v->Value();
   obj->gzIface->SetPoseFilterMinimumDistanceSquared(value);
 
@@ -212,17 +212,17 @@ NAN_METHOD(GZNode::SetPoseMsgFilterMinimumDistanceSquared)
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::GetPoseMsgFilterMinimumDistanceSquared)
 {
-  Isolate* isolate = args.GetIsolate();
-  GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
+  Isolate* isolate = info.GetIsolate();
+  GZNode *obj = ObjectWrap::Unwrap<GZNode>(info.This());
   double value  = obj->gzIface->GetPoseFilterMinimumDistanceSquared();
-  args.GetReturnValue().Set(Number::New(isolate ,value));
+  info.GetReturnValue().Set(Number::New(isolate ,value));
 }
 
 /////////////////////////////////////////////////////
 NAN_METHOD(GZNode::SetPoseMsgFilterMinimumQuaternionSquared)
 {
-  GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
-  Local<Number> v = Local<Number>::Cast(args[0]);
+  GZNode *obj = ObjectWrap::Unwrap<GZNode>(info.This());
+  Local<Number> v = Local<Number>::Cast(info[0]);
   double value = v->Value();
   obj->gzIface->SetPoseFilterMinimumQuaternionSquared(value);
 
@@ -232,22 +232,22 @@ NAN_METHOD(GZNode::SetPoseMsgFilterMinimumQuaternionSquared)
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::GetPoseMsgFilterMinimumQuaternionSquared)
 {
-  Isolate* isolate = args.GetIsolate();
-  GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
+  Isolate* isolate = info.GetIsolate();
+  GZNode *obj = ObjectWrap::Unwrap<GZNode>(info.This());
   double value  = obj->gzIface->GetPoseFilterMinimumQuaternionSquared();
-  args.GetReturnValue().Set(Number::New(isolate ,value));
+  info.GetReturnValue().Set(Number::New(isolate ,value));
 }
 
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::GetMessages)
 {
-  Isolate* isolate = args.GetIsolate();
+  Isolate* isolate = info.GetIsolate();
   Local<Context> context = isolate->GetCurrentContext();
 
-  GZNode* obj = ObjectWrap::Unwrap<GZNode>(args.This());
+  GZNode* obj = ObjectWrap::Unwrap<GZNode>(info.This());
 
   std::vector<std::string> msgs = obj->gzIface->PopOutgoingMessages();
-  // args.GetReturnValue().Set(Number::New(isolate ,msgs.size()));
+  // info.GetReturnValue().Set(Number::New(isolate ,msgs.size()));
   Local<Array> arguments = Array::New(isolate, msgs.size());
   for (unsigned int i = 0; i < msgs.size(); ++i) {
     MaybeLocal<String> v8_msg = String::NewFromUtf8(isolate, msgs[i].c_str(), NewStringType::kNormal);
@@ -258,16 +258,16 @@ NAN_METHOD(GZNode::GetMessages)
     }
   }
 
-  args.GetReturnValue().Set(arguments);
+  info.GetReturnValue().Set(arguments);
 }
 
 
 ////////////////////////////////////////////////
 NAN_METHOD(GZNode::Request)
 {
-  Isolate* isolate = args.GetIsolate();
+  Isolate* isolate = info.GetIsolate();
 
-  if (args.Length() < 1)
+  if (info.Length() < 1)
   {
     isolate->ThrowException(Exception::TypeError(
         String::NewFromUtf8(isolate, 
@@ -276,7 +276,7 @@ NAN_METHOD(GZNode::Request)
     return;
   }
 
-  if (!args[0]->IsString())
+  if (!info[0]->IsString())
   {
     isolate->ThrowException(Exception::TypeError(
         String::NewFromUtf8(isolate, 
@@ -285,9 +285,9 @@ NAN_METHOD(GZNode::Request)
     return;
   }
 
-  GZNode* obj = ObjectWrap::Unwrap<GZNode>(args.This());
+  GZNode* obj = ObjectWrap::Unwrap<GZNode>(info.This());
 
-  String::Utf8Value request(isolate, args[0]);
+  String::Utf8Value request(isolate, info[0]);
   obj->gzIface->PushRequest(std::string(*request));
 
   return;
@@ -296,8 +296,8 @@ NAN_METHOD(GZNode::Request)
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::SetPoseMsgFilterMinimumAge)
 {
-  GZNode* obj = ObjectWrap::Unwrap<GZNode>(args.This());
-  Local<Number> v = Local<Number>::Cast(args[0]);
+  GZNode* obj = ObjectWrap::Unwrap<GZNode>(info.This());
+  Local<Number> v = Local<Number>::Cast(info[0]);
   double value = v->Value();
   obj->gzIface->SetPoseFilterMinimumMsgAge(value);
 
@@ -307,9 +307,9 @@ NAN_METHOD(GZNode::SetPoseMsgFilterMinimumAge)
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::GetPoseMsgFilterMinimumAge)
 {
-  GZNode* obj = ObjectWrap::Unwrap<GZNode>(args.This());
+  GZNode* obj = ObjectWrap::Unwrap<GZNode>(info.This());
   double value  = obj->gzIface->GetPoseFilterMinimumMsgAge();
-  args.GetReturnValue().Set(value);
+  info.GetReturnValue().Set(value);
 }
 
 /////////////////////////////////////////////////

--- a/gzbridge/GZNode.cc
+++ b/gzbridge/GZNode.cc
@@ -59,29 +59,29 @@ void GZNode::Init(Local<Object> exports)
   tpl->SetClassName(class_name);
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   // Prototype
-  NODE_SET_PROTOTYPE_METHOD(tpl, "loadMaterialScripts", LoadMaterialScripts);
+  Nan::SetPrototypeMethod(tpl, "loadMaterialScripts", LoadMaterialScripts);
 
-  NODE_SET_PROTOTYPE_METHOD(tpl, "setConnected", SetConnected);
+  Nan::SetPrototypeMethod(tpl, "setConnected", SetConnected);
 
-  NODE_SET_PROTOTYPE_METHOD(tpl, "setPoseMsgFilterMinimumDistanceSquared", SetPoseMsgFilterMinimumDistanceSquared);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "getPoseMsgFilterMinimumDistanceSquared", GetPoseMsgFilterMinimumDistanceSquared);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "setPoseMsgFilterMinimumQuaternionSquared", SetPoseMsgFilterMinimumQuaternionSquared);
-  NODE_SET_PROTOTYPE_METHOD(tpl, "getPoseMsgFilterMinimumQuaternionSquared", GetPoseMsgFilterMinimumQuaternionSquared);
+  Nan::SetPrototypeMethod(tpl, "setPoseMsgFilterMinimumDistanceSquared", SetPoseMsgFilterMinimumDistanceSquared);
+  Nan::SetPrototypeMethod(tpl, "getPoseMsgFilterMinimumDistanceSquared", GetPoseMsgFilterMinimumDistanceSquared);
+  Nan::SetPrototypeMethod(tpl, "setPoseMsgFilterMinimumQuaternionSquared", SetPoseMsgFilterMinimumQuaternionSquared);
+  Nan::SetPrototypeMethod(tpl, "getPoseMsgFilterMinimumQuaternionSquared", GetPoseMsgFilterMinimumQuaternionSquared);
 
-  NODE_SET_PROTOTYPE_METHOD(tpl, "getPoseMsgFilterMinimumAge",
+  Nan::SetPrototypeMethod(tpl, "getPoseMsgFilterMinimumAge",
       GetPoseMsgFilterMinimumAge);
 
-  NODE_SET_PROTOTYPE_METHOD(tpl, "setPoseMsgFilterMinimumAge",
+  Nan::SetPrototypeMethod(tpl, "setPoseMsgFilterMinimumAge",
       SetPoseMsgFilterMinimumAge);
 
-  NODE_SET_PROTOTYPE_METHOD(tpl, "getMessages", GetMessages);
+  Nan::SetPrototypeMethod(tpl, "getMessages", GetMessages);
 
-  NODE_SET_PROTOTYPE_METHOD(tpl, "request", Request);
+  Nan::SetPrototypeMethod(tpl, "request", Request);
 
-  NODE_SET_PROTOTYPE_METHOD(tpl, "getIsGzServerConnected",
+  Nan::SetPrototypeMethod(tpl, "getIsGzServerConnected",
       GetIsGzServerConnected);
 
-  NODE_SET_PROTOTYPE_METHOD(tpl, "getMaterialScriptsMessage",
+  Nan::SetPrototypeMethod(tpl, "getMaterialScriptsMessage",
       GetMaterialScriptsMessage);
 
   Local<Context> context = isolate->GetCurrentContext();

--- a/gzbridge/GZNode.cc
+++ b/gzbridge/GZNode.cc
@@ -84,8 +84,9 @@ void GZNode::Init(Local<Object> exports)
   Nan::SetPrototypeMethod(tpl, "getMaterialScriptsMessage",
       GetMaterialScriptsMessage);
 
-  Local<Context> context = isolate->GetCurrentContext();
-  exports->Set(context, class_name, tpl->GetFunction(context).ToLocalChecked()).ToChecked();
+  target->Set(Nan::GetCurrentContext(), class_name, 
+    tpl->GetFunction(Nan::GetCurrentContext()).ToLocalChecked()
+    ).ToChecked();
 }
 
 /////////////////////////////////////////////////
@@ -127,16 +128,9 @@ NAN_METHOD(GZNode::LoadMaterialScripts)
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::SetConnected)
 {
-  Isolate* isolate = info.GetIsolate();
 
   GZNode *obj = ObjectWrap::Unwrap<GZNode>(info.This());
-
-#if NODE_MAJOR_VERSION<=10
-  Local<Context> context = isolate->GetCurrentContext();
-  bool value = info[0]->BooleanValue(context).ToChecked();
-#else
-  bool value = info[0]->BooleanValue(isolate);
-#endif
+  bool value = Nan::To<bool>(info[0]).ToChecked();
   obj->gzIface->SetConnected(value);
 
   return;
@@ -177,10 +171,7 @@ NAN_METHOD(GZNode::GetMaterialScriptsMessage)
   msg += materialJson;
   msg += "}";
 
-  info.GetReturnValue().Set(
-    String::NewFromUtf8(isolate,
-      msg.c_str(), 
-      NewStringType::kNormal).ToLocalChecked());
+  info.GetReturnValue().Set(Nan::New(msg.c_str()).ToLocalChecked());
 }
 
 /////////////////////////////////////////////////
@@ -188,7 +179,7 @@ NAN_METHOD(GZNode::SetPoseMsgFilterMinimumDistanceSquared)
 {
   GZNode *obj = ObjectWrap::Unwrap<GZNode>(info.This());
 
-  Local<Number> v = Local<Number>::Cast(info[0]);
+  Local<Number> v = Nan::To<Number>(info[0]).ToLocalChecked();
   double value = v->Value();
   obj->gzIface->SetPoseFilterMinimumDistanceSquared(value);
 
@@ -198,17 +189,16 @@ NAN_METHOD(GZNode::SetPoseMsgFilterMinimumDistanceSquared)
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::GetPoseMsgFilterMinimumDistanceSquared)
 {
-  Isolate* isolate = info.GetIsolate();
   GZNode *obj = ObjectWrap::Unwrap<GZNode>(info.This());
   double value  = obj->gzIface->GetPoseFilterMinimumDistanceSquared();
-  info.GetReturnValue().Set(Number::New(isolate ,value));
+  info.GetReturnValue().Set(Nan::New<Number>(value));
 }
 
 /////////////////////////////////////////////////////
 NAN_METHOD(GZNode::SetPoseMsgFilterMinimumQuaternionSquared)
 {
   GZNode *obj = ObjectWrap::Unwrap<GZNode>(info.This());
-  Local<Number> v = Local<Number>::Cast(info[0]);
+  Local<Number> v = Nan::To<Number>(info[0]).ToLocalChecked();
   double value = v->Value();
   obj->gzIface->SetPoseFilterMinimumQuaternionSquared(value);
 
@@ -218,30 +208,22 @@ NAN_METHOD(GZNode::SetPoseMsgFilterMinimumQuaternionSquared)
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::GetPoseMsgFilterMinimumQuaternionSquared)
 {
-  Isolate* isolate = info.GetIsolate();
   GZNode *obj = ObjectWrap::Unwrap<GZNode>(info.This());
   double value  = obj->gzIface->GetPoseFilterMinimumQuaternionSquared();
-  info.GetReturnValue().Set(Number::New(isolate ,value));
+  info.GetReturnValue().Set(Nan::New<Number>(value));
 }
 
 /////////////////////////////////////////////////
 NAN_METHOD(GZNode::GetMessages)
 {
-  Isolate* isolate = info.GetIsolate();
-  Local<Context> context = isolate->GetCurrentContext();
 
   GZNode* obj = ObjectWrap::Unwrap<GZNode>(info.This());
 
   std::vector<std::string> msgs = obj->gzIface->PopOutgoingMessages();
-  // info.GetReturnValue().Set(Number::New(isolate ,msgs.size()));
-  Local<Array> arguments = Array::New(isolate, msgs.size());
+  Local<Array> arguments = Nan::New<Array>(msgs.size());
   for (unsigned int i = 0; i < msgs.size(); ++i) {
-    MaybeLocal<String> v8_msg = String::NewFromUtf8(isolate, msgs[i].c_str(), NewStringType::kNormal);
-    bool sucess = arguments->Set(context, i, v8_msg.ToLocalChecked()).FromJust();
-    if(!sucess){
-      //TODO handle failure
-      return;
-    }
+    Local<String> v8_msg = Nan::New<String>(msgs[i].c_str()).ToLocalChecked();
+    Nan::Set(arguments, i, v8_msg);
   }
 
   info.GetReturnValue().Set(arguments);
@@ -275,7 +257,7 @@ NAN_METHOD(GZNode::Request)
 NAN_METHOD(GZNode::SetPoseMsgFilterMinimumAge)
 {
   GZNode* obj = ObjectWrap::Unwrap<GZNode>(info.This());
-  Local<Number> v = Local<Number>::Cast(info[0]);
+  Local<Number> v = Nan::To<Number>(info[0]).ToLocalChecked();
   double value = v->Value();
   obj->gzIface->SetPoseFilterMinimumMsgAge(value);
 

--- a/gzbridge/GZNode.cc
+++ b/gzbridge/GZNode.cc
@@ -47,7 +47,7 @@ GZNode::~GZNode()
 };
 
 /////////////////////////////////////////////////
-void GZNode::Init(Handle<Object> exports)
+void GZNode::Init(Local<Object> exports)
 {
   Isolate* isolate = exports->GetIsolate();
   // Prepare constructor template
@@ -286,7 +286,7 @@ void GZNode::GetPoseMsgFilterMinimumAge(const
 }
 
 /////////////////////////////////////////////////
-void InitAll(Handle<Object> exports)
+void InitAll(Local<Object> exports)
 {
   GZNode::Init(exports);
 }

--- a/gzbridge/GZNode.cc
+++ b/gzbridge/GZNode.cc
@@ -85,7 +85,7 @@ void GZNode::Init(Local<Object> exports)
       GetMaterialScriptsMessage);
 
   Local<Context> context = isolate->GetCurrentContext();
-  exports->Set(context, class_name, tpl->GetFunction(context).ToLocalChecked()).Check();
+  exports->Set(context, class_name, tpl->GetFunction(context).ToLocalChecked()).ToChecked();
 }
 
 /////////////////////////////////////////////////
@@ -136,7 +136,13 @@ void GZNode::SetConnected(const FunctionCallbackInfo<Value>& args)
   Isolate* isolate = args.GetIsolate();
 
   GZNode *obj = ObjectWrap::Unwrap<GZNode>(args.This());
+
+#if NODE_MAJOR_VERSION<=10
+  Local<Context> context = isolate->GetCurrentContext();
+  bool value = args[0]->BooleanValue(context).ToChecked();
+#else
   bool value = args[0]->BooleanValue(isolate);
+#endif
   obj->gzIface->SetConnected(value);
 
   return;

--- a/gzbridge/GZNode.cc
+++ b/gzbridge/GZNode.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <node.h>
+#include <nan.h>
 #include "GZNode.hh"
 
 #include "GazeboInterface.hh"

--- a/gzbridge/GZNode.cc
+++ b/gzbridge/GZNode.cc
@@ -107,14 +107,18 @@ void GZNode::LoadMaterialScripts(const FunctionCallbackInfo<Value>& args)
   if (args.Length() < 1)
   {
     isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
+      String::NewFromUtf8(isolate, 
+        "Wrong number of arguments", 
+        NewStringType::kNormal).ToLocalChecked()));
     return;
   }
 
   if (!args[0]->IsString())
   {
     isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong argument type. String expected.")));
+        String::NewFromUtf8(isolate, 
+          "Wrong argument type. String expected.", 
+          NewStringType::kNormal).ToLocalChecked()));
     return;
   }
 
@@ -155,14 +159,18 @@ void GZNode::GetMaterialScriptsMessage(const FunctionCallbackInfo<Value>& args)
   if (args.Length() < 1)
   {
     isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
+        String::NewFromUtf8(isolate, 
+          "Wrong number of arguments", 
+          NewStringType::kNormal).ToLocalChecked()));
     return;
   }
 
   if (!args[0]->IsString())
   {
     isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong argument type. String expected.")));
+        String::NewFromUtf8(isolate, 
+          "Wrong argument type. String expected.",
+          NewStringType::kNormal).ToLocalChecked()));
     return;
   }
 
@@ -177,7 +185,10 @@ void GZNode::GetMaterialScriptsMessage(const FunctionCallbackInfo<Value>& args)
   msg += materialJson;
   msg += "}";
 
-  args.GetReturnValue().Set(String::NewFromUtf8(isolate ,msg.c_str()));
+  args.GetReturnValue().Set(
+    String::NewFromUtf8(isolate,
+      msg.c_str(), 
+      NewStringType::kNormal).ToLocalChecked());
 }
 
 /////////////////////////////////////////////////
@@ -229,6 +240,7 @@ void GZNode::GetPoseMsgFilterMinimumQuaternionSquared(const
 void GZNode::GetMessages(const FunctionCallbackInfo<Value>& args)
 {
   Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
 
   GZNode* obj = ObjectWrap::Unwrap<GZNode>(args.This());
 
@@ -236,7 +248,12 @@ void GZNode::GetMessages(const FunctionCallbackInfo<Value>& args)
   // args.GetReturnValue().Set(Number::New(isolate ,msgs.size()));
   Local<Array> arguments = Array::New(isolate, msgs.size());
   for (unsigned int i = 0; i < msgs.size(); ++i) {
-    arguments->Set(i ,String::NewFromUtf8(isolate, msgs[i].c_str()));
+    MaybeLocal<String> v8_msg = String::NewFromUtf8(isolate, msgs[i].c_str(), NewStringType::kNormal);
+    bool sucess = arguments->Set(context, i, v8_msg.ToLocalChecked()).FromJust();
+    if(!sucess){
+      //TODO handle failure
+      return;
+    }
   }
 
   args.GetReturnValue().Set(arguments);
@@ -251,14 +268,18 @@ void GZNode::Request(const FunctionCallbackInfo<Value>& args)
   if (args.Length() < 1)
   {
     isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong number of arguments")));
+        String::NewFromUtf8(isolate, 
+          "Wrong number of arguments", 
+          NewStringType::kNormal).ToLocalChecked()));
     return;
   }
 
   if (!args[0]->IsString())
   {
     isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Wrong argument type. String expected.")));
+        String::NewFromUtf8(isolate, 
+          "Wrong argument type. String expected.",
+          NewStringType::kNormal).ToLocalChecked()));
     return;
   }
 

--- a/gzbridge/GZNode.cc
+++ b/gzbridge/GZNode.cc
@@ -313,7 +313,7 @@ void GZNode::GetPoseMsgFilterMinimumAge(const
 }
 
 /////////////////////////////////////////////////
-void InitAll(Local<Object> exports)
+void InitAll(Local<Object> exports, Local<Value> module, void* priv)
 {
   GZNode::Init(exports);
 }

--- a/gzbridge/GZNode.cc
+++ b/gzbridge/GZNode.cc
@@ -47,14 +47,12 @@ GZNode::~GZNode()
 };
 
 /////////////////////////////////////////////////
-void GZNode::Init(Local<Object> exports)
+NAN_MODULE_INIT(GZNode::Init)
 {
-  Isolate* isolate = exports->GetIsolate();
   // Prepare constructor template
-  Local<String> class_name = String::NewFromUtf8(isolate, "GZNode",
-      NewStringType::kInternalized).ToLocalChecked();
+  Local<String> class_name = Nan::New("GZNode").ToLocalChecked();
 
-  Local<FunctionTemplate> tpl = FunctionTemplate::New(isolate, New);
+  Local<FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(GZNode::New);
 
   tpl->SetClassName(class_name);
   tpl->InstanceTemplate()->SetInternalFieldCount(1);

--- a/gzbridge/GZNode.hh
+++ b/gzbridge/GZNode.hh
@@ -33,7 +33,7 @@ namespace gzweb
 
   class GZNode : public node::ObjectWrap
   {
-    public: static void Init(v8::Handle<v8::Object> exports);
+    public: static void Init(v8::Local<v8::Object> exports);
 
     private: GZNode();
 

--- a/gzbridge/GZNode.hh
+++ b/gzbridge/GZNode.hh
@@ -18,8 +18,7 @@
 #ifndef GZBRIDGE_GZNODE_HH_
 #define GZBRIDGE_GZNODE_HH_
 
-#include <node.h>
-#include <node_object_wrap.h>
+#include <nan.h>
 
 namespace gzweb
 {
@@ -31,7 +30,7 @@ namespace gzweb
 
   class GazeboInterface;
 
-  class GZNode : public node::ObjectWrap
+  class GZNode : public Nan::ObjectWrap
   {
     public: static NAN_MODULE_INIT(Init);
 

--- a/gzbridge/GZNode.hh
+++ b/gzbridge/GZNode.hh
@@ -22,11 +22,6 @@
 
 namespace gzweb
 {
-  using v8::FunctionCallbackInfo;
-  using v8::Value;
-  using v8::FunctionTemplate;
-  using v8::Object;
-  using v8::Persistent;
 
   class GazeboInterface;
 

--- a/gzbridge/GZNode.hh
+++ b/gzbridge/GZNode.hh
@@ -33,47 +33,37 @@ namespace gzweb
 
   class GZNode : public node::ObjectWrap
   {
-    public: static void Init(v8::Local<v8::Object> exports);
+    public: static NAN_MODULE_INIT(Init);
 
     private: GZNode();
 
     private: ~GZNode();
 
-    private: static void New(const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(New);
 
-    private: static void LoadMaterialScripts(
-        const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(LoadMaterialScripts);
 
-    private: static void SetConnected(
-        const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(SetConnected);
 
-    private: static void GetIsGzServerConnected(
-        const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(GetIsGzServerConnected);
 
-    private: static void GetMaterialScriptsMessage(
-        const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(GetMaterialScriptsMessage);
 
-    private: static void SetPoseMsgFilterMinimumDistanceSquared(
-        const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(SetPoseMsgFilterMinimumDistanceSquared);
 
-    private: static void GetPoseMsgFilterMinimumDistanceSquared(
-        const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(GetPoseMsgFilterMinimumDistanceSquared);
 
-    private: static void SetPoseMsgFilterMinimumQuaternionSquared(
-        const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(SetPoseMsgFilterMinimumQuaternionSquared);
 
-    private: static void GetPoseMsgFilterMinimumQuaternionSquared(
-        const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(GetPoseMsgFilterMinimumQuaternionSquared);
 
-    private: static void GetMessages(const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(GetMessages);
 
-    private: static void Request(const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(Request);
 
-    private: static void SetPoseMsgFilterMinimumAge(
-        const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(SetPoseMsgFilterMinimumAge);
 
-    private: static void GetPoseMsgFilterMinimumAge(
-        const FunctionCallbackInfo<Value>& args);
+    private: static NAN_METHOD(GetPoseMsgFilterMinimumAge);
 
     private: GazeboInterface* gzIface = nullptr;
 

--- a/gzbridge/binding.gyp
+++ b/gzbridge/binding.gyp
@@ -7,6 +7,9 @@
         "pb2json.cc", "pb2json.hh",
         "ConfigLoader.cc", "ConfigLoader.hh",
         "OgreMaterialParser.cc", "OgreMaterialParser.hh"],
+      "include_dirs" : [
+        "<!(node -e \"require('nan')\")"
+      ],
       'cflags_cc!': [ '-fno-rtti', '-fno-exceptions' ],
       'cflags!': [ '-fno-exceptions' ],
       "cflags_cc": [ '-std=c++17', '-Wall'],

--- a/gzbridge/binding.gyp
+++ b/gzbridge/binding.gyp
@@ -9,6 +9,7 @@
         "OgreMaterialParser.cc", "OgreMaterialParser.hh"],
       'cflags_cc!': [ '-fno-rtti', '-fno-exceptions' ],
       'cflags!': [ '-fno-exceptions' ],
+      "cflags_cc": [ '-std=c++17' ],
       "conditions": [
         ['OS=="linux"', {
           'cflags': [

--- a/gzbridge/binding.gyp
+++ b/gzbridge/binding.gyp
@@ -9,7 +9,7 @@
         "OgreMaterialParser.cc", "OgreMaterialParser.hh"],
       'cflags_cc!': [ '-fno-rtti', '-fno-exceptions' ],
       'cflags!': [ '-fno-exceptions' ],
-      "cflags_cc": [ '-std=c++17' ],
+      "cflags_cc": [ '-std=c++17', '-Wall'],
       "conditions": [
         ['OS=="linux"', {
           'cflags': [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "fs": "0.0.1-security",
     "http": "0.0.0",
+    "nan": "^2.14.2",
     "node-gyp": "6.1.0",
     "path": "^0.12.7",
     "websocket": "^1.0.25"

--- a/tools/gzcoarse.cc
+++ b/tools/gzcoarse.cc
@@ -134,7 +134,7 @@ void ExportTextureSource(const gazebo::common::SubMesh *_outSubMesh,
   std::vector<size_t> result_index(num_results);
   std::vector<double> out_dist_sqr(num_results);
   static const int offset[] = {1,2,-1,1,-2,-1};
-  for (int i = 0; i < outTriIndexCount; ++i)
+  for (unsigned int i = 0; i < outTriIndexCount; ++i)
   {
     unsigned int outIndex = _outSubMesh->GetIndex(i);
     ignition::math::Vector3d outVertex = _outSubMesh->Vertex(outIndex);
@@ -146,7 +146,7 @@ void ExportTextureSource(const gazebo::common::SubMesh *_outSubMesh,
 
     std::vector<size_t> closestIndices;
     double closestDistance = 1000;
-    for (int j = 0; j < num_results; ++j)
+    for (unsigned int j = 0; j < num_results; ++j)
     {
       inVertex = _inSubMesh->Vertex(result_index[j]);
 
@@ -214,7 +214,7 @@ void ExportTextureSource(const gazebo::common::SubMesh *_outSubMesh,
 
     // Find the closest direction among all triangles containing overlapping
     // vertices
-    for (int k = 1; k < closestIndices.size(); ++k)
+    for (unsigned int k = 1; k < closestIndices.size(); ++k)
     {
       // Current vertex
       size_t currentIndex = closestIndices[k];
@@ -1246,7 +1246,7 @@ int main(int argc, char **argv)
 
   gazebo::common::Mesh *outGz = new gazebo::common::Mesh();
 
-  for (int s = 0; s < inGz->GetSubMeshCount(); ++s)
+  for (unsigned int s = 0; s < inGz->GetSubMeshCount(); ++s)
   {
     const gazebo::common::SubMesh *inSubMesh = inGz->GetSubMesh(s);
 


### PR DESCRIPTION
Hello everyone,

From v8 version 6.0 (shipped w/ node 10) to v8 7.0 (shipped w/ node 12), there was a major change in API methods that prevented the project to run with node 12. Unfortunately, these changes break compatibility with node 8.x and 10.x as well, maybe it is interesting to release a major version of gzweb.

This PR addresses this problem and changes the calls to v8 API following the new syntax. No logic or functional changes were made.

Another change is the update to Gazebo version 11. It was necessary to pass the flag `-std=c++17` in order tho compile the dependency sdf format version 9.0

Thank you everyone! =)

Useful references:

**v8/node deprecated APIs and how to handle them** https://github.com/bcoin-org/bcrypto/issues/7
**APIs removed in V8 7.0 and native addons** https://github.com/nodejs/node/issues/23122
**[v10.x] deps: increase V8 deprecation levels** https://github.com/nodejs/node/pull/23159
**Properly handle the requirement of C++17 at the CMake exported target level** https://github.com/osrf/sdformat/pull/251

Closes #204
Closes #203 
Closes #174