### PR TITLE
Add nullptr check for statsMsg

### DIFF
--- a/gzbridge/GazeboInterface.cc
+++ b/gzbridge/GazeboInterface.cc
@@ -710,7 +710,7 @@ void GazeboInterface::ProcessMessages()
           // simulate latching stats topic
           if (this->statsMsgs.empty() && this->statsMsg.get() != nullptr)
           {
-              this->statsMsgs.push_back(this->statsMsg);
+            this->statsMsgs.push_back(this->statsMsg);
           }
         }
       }


### PR DESCRIPTION
If a JS-side request for subscription to `~/world_stats` is received before gzbridge has received a message on the concrete topic from gazebo, an uninitialised shared_ptr is pushed into the `statsMsgs` vector. This then propagates and ultimately causes the segfault in `pb2json.cc`'s `parse_msg()` function via some protobuf calls.

Potentially fixes #155