### PR TITLE
Update model scripts to Python 3

### DIFF
--- a/get_local_models.py
+++ b/get_local_models.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import sys

--- a/webify_models_v2.py
+++ b/webify_models_v2.py
@@ -56,14 +56,14 @@ for file in files:
 
       if texture_dir != dest_dir:
         cmd = ['mv', dest_path, texture_dir]
-        print cmd
+        print(cmd)
         subprocess.check_call(cmd)
 
     # update texture path in dae files
     if format.lower() in ['dae']:
       sed_cmd = ["sed", "-i", "-e",
         's/\(\.tga\|\.tiff\|\.tif\|\.jpg\|\.jpeg\|\.gif\)/\.png/g', file]
-      print sed_cmd
+      print(sed_cmd)
       subprocess.check_call(sed_cmd)
 
       # find relatvie path to texture dir
@@ -79,21 +79,21 @@ for file in files:
         # replace dae file png references to texture path
         sed_cmd = ["sed", "-i","-e",
           's/\(>\)\(.*\/\)\(.*\.png\)/\\1'+ relative_path + 'materials\/textures\/\\3/g', file]
-        print sed_cmd
+        print(sed_cmd)
         subprocess.check_call(sed_cmd)
 
         sed_cmd = ["sed", "-i","-e",
           '/[a-zA-Z0-9_\.\/\-]\+materials\/textures/!s/\([a-zA-Z0-9_\-]\+\)\(\.png\W\)/'+ relative_path + 'materials\/textures\/\\1\\2/g', file]
 
-        print sed_cmd
+        print(sed_cmd)
         subprocess.check_call(sed_cmd)
 
     if format.lower() in ['material', 'txt', 'sdf']:
       sed_cmd = ["sed", "-i", "-e",
         's/\(\.tga\|\.tiff\|\.tif\|\.jpg\|\.jpeg\|\.gif\)/\.png/g', file]
-      print sed_cmd
+      print(sed_cmd)
       subprocess.check_call(sed_cmd)
 
-  except Exception, e:
-      print "error %s" % e
+  except Exception as e:
+      print("error %s" % e)
       raise

--- a/webify_models_v2.py
+++ b/webify_models_v2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # A script to update gazebo models to be web-friendly.
 # It converts all textures to png format and make sure they are


### PR DESCRIPTION
This updates model scripts from Python 2 to Python 3. Otherwise these helper scripts will silently fail when called from `deploy.sh` using non-EOL distros.

---

These scripts are still need to avoid issues with resolving URIs for mesh file paths:

- https://github.com/aws-robotics/aws-robomaker-small-warehouse-world/pull/24